### PR TITLE
do not fail on same pulse processing

### DIFF
--- a/internal/app/observer/store/pg/store.go
+++ b/internal/app/observer/store/pg/store.go
@@ -142,7 +142,8 @@ func (s *Store) SetResult(ctx context.Context, resultRecord record.Material) err
 		return errors.Wrap(err, "failed to marshal result")
 	}
 
-	_, err = s.db.ExecContext(ctx, `insert into raw_results (request_id, result_body) values (?, ?)`,
+	_, err = s.db.ExecContext(ctx, `insert into raw_results (request_id, result_body) values (?, ?)
+                                           ON CONFLICT DO NOTHING`,
 		id.String(), body)
 
 	return errors.Wrap(err, "failed to insert result")
@@ -165,7 +166,8 @@ func (s *Store) SetSideEffect(ctx context.Context, sideEffectRecord record.Mater
 		return errors.Wrap(err, "failed to marshal side effect")
 	}
 
-	_, err = s.db.ExecContext(ctx, `insert into raw_side_effects (request_id, side_effect_body) values (?, ?)`,
+	_, err = s.db.ExecContext(ctx, `insert into raw_side_effects (request_id, side_effect_body) values (?, ?)
+                                           ON CONFLICT DO NOTHING`,
 		id.String(), body)
 
 	return errors.Wrap(err, "failed to insert result")
@@ -182,7 +184,8 @@ func (s *Store) SetRequest(ctx context.Context, requestRecord record.Material) e
 		return errors.Wrap(err, "failed to marshal request")
 	}
 
-	_, err = s.db.ExecContext(ctx, `insert into raw_requests (request_id, reason_id, request_body) values (?, ?, ?)`,
+	_, err = s.db.ExecContext(ctx, `insert into raw_requests (request_id, reason_id, request_body) values (?, ?, ?)
+                                           ON CONFLICT DO NOTHING`,
 		id.String(), reason.String(), body)
 
 	return errors.Wrap(err, "failed to insert request")

--- a/internal/app/observer/store/pg/store_test.go
+++ b/internal/app/observer/store/pg/store_test.go
@@ -131,6 +131,33 @@ func TestStore_RequestBadRecord(t *testing.T) {
 	require.Error(t, store.SetRequest(ctx, *request))
 }
 
+func TestStore_DuplicateRequest(t *testing.T) {
+	request := makeRequestWith("some", gen.RecordReference(), nil)
+	store := NewPgStore(db)
+	ctx := context.Background()
+	require.NoError(t, store.SetRequest(ctx, *request))
+
+	require.NoError(t, store.SetRequest(ctx, *request))
+}
+
+func TestStore_DuplicateResult(t *testing.T) {
+	result := makeResultWith(gen.ID(), gen.RecordReference(), nil)
+	store := NewPgStore(db)
+	ctx := context.Background()
+	require.NoError(t, store.SetResult(ctx, *result))
+
+	require.NoError(t, store.SetResult(ctx, *result))
+}
+
+func TestStore_DuplicateSideEffect(t *testing.T) {
+	sideEffect := makeSideEffectWith(gen.RecordReference(), nil)
+	store := NewPgStore(db)
+	ctx := context.Background()
+	require.NoError(t, store.SetSideEffect(ctx, *sideEffect))
+
+	require.NoError(t, store.SetSideEffect(ctx, *sideEffect))
+}
+
 func TestStore_RequestNotFound(t *testing.T) {
 	pgStore := NewPgStore(db)
 	queryReq, err := pgStore.Request(context.Background(), gen.ID())


### PR DESCRIPTION
added on duplicate key do nothing to be able to process same pulse batch