### PR TITLE
support for empty requestID genesisrefs

### DIFF
--- a/internal/app/observer/store/pg/store.go
+++ b/internal/app/observer/store/pg/store.go
@@ -47,6 +47,7 @@ type RawResult struct {
 }
 
 type RawSideEffect struct {
+	ID        string `sql:"id"`
 	RequestID string `sql:"request_id"`
 	Body      []byte `sql:"side_effect_body"`
 }
@@ -156,7 +157,7 @@ func (s *Store) SetSideEffect(ctx context.Context, sideEffectRecord record.Mater
 		return errors.Errorf("trying to save not a side effect as side effect")
 	}
 
-	id, err := store.RequestID(&sideEffectRecord)
+	requestID, err := store.RequestID(&sideEffectRecord)
 	if err != nil {
 		return errors.Wrap(err, "failed to parse side effect data")
 	}
@@ -166,9 +167,9 @@ func (s *Store) SetSideEffect(ctx context.Context, sideEffectRecord record.Mater
 		return errors.Wrap(err, "failed to marshal side effect")
 	}
 
-	_, err = s.db.ExecContext(ctx, `insert into raw_side_effects (request_id, side_effect_body) values (?, ?)
+	_, err = s.db.ExecContext(ctx, `insert into raw_side_effects (id, request_id, side_effect_body) values (?, ?, ?)
                                            ON CONFLICT DO NOTHING`,
-		id.String(), body)
+		sideEffectRecord.ID.String(), requestID.String(), body)
 
 	return errors.Wrap(err, "failed to insert result")
 }

--- a/scripts/migrations/1_scheme.up.sql
+++ b/scripts/migrations/1_scheme.up.sql
@@ -17,9 +17,6 @@ create table if not exists raw_requests
     request_body bytea not null
 );
 
-create index if not exists idx_raw_requests_by_id
-    on raw_requests (request_id);
-
 create table if not exists raw_results
 (
     request_id varchar(256) not null
@@ -28,14 +25,12 @@ create table if not exists raw_results
     result_body bytea not null
 );
 
-create index if not exists idx_raw_results_by_request_id
-    on raw_requests (request_id);
-
 create table if not exists raw_side_effects
 (
-    request_id varchar(256) not null
+    id varchar(256) not null
         constraint raw_side_effects_pk
-        primary key,
+            primary key,
+    request_id varchar(256) not null,
     side_effect_body bytea not null
 );
 


### PR DESCRIPTION
genesis objects are created on one requestID