### PR TITLE
INS-3916: error return from migration doesn't mean failed txn

### DIFF
--- a/internal/app/observer/collecting/transactions.go
+++ b/internal/app/observer/collecting/transactions.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	callSiteTransfer  = "member.transfer"
-	callSiteMigration = "deposit.migration"
 	callSiteRelease   = "deposit.transfer"
 )
 
@@ -591,9 +590,8 @@ func (c *TxSagaResultCollector) fromCall(
 	}
 
 	isTransfer := args.Params.CallSite == callSiteTransfer
-	isMigration := args.Params.CallSite == callSiteMigration
 	isRelease := args.Params.CallSite == callSiteRelease
-	if !isTransfer && !isMigration && !isRelease {
+	if !isTransfer && !isRelease {
 		log.Debug("skipped (request callSite is not parsable)")
 		return nil
 	}


### PR DESCRIPTION
we don't create migration transaction until TransferToDeposit, this
happens after two out of three confirmation had success, some could
fail with error