### PR TITLE
WLT-1375: use latest pulse from DB instead of NOW()

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -30,6 +30,7 @@ import (
 
 	apiconfiguration "github.com/insolar/observer/configuration/api"
 	"github.com/insolar/observer/internal/app/api"
+	"github.com/insolar/observer/internal/app/observer/postgres"
 	"github.com/insolar/observer/internal/dbconn"
 )
 
@@ -59,7 +60,8 @@ func main() {
 	e.Use(echoPrometheus.MetricsMiddleware())
 	e.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
 
-	observerAPI := api.NewObserverServer(db, logger, cfg.FeeAmount, &api.DefaultClock{}, cfg.Price)
+	pStorage := postgres.NewPulseStorage(logger, db)
+	observerAPI := api.NewObserverServer(db, logger, cfg.FeeAmount, pStorage, cfg.Price)
 	api.RegisterHandlers(e, observerAPI)
 
 	e.Logger.Fatal(e.Start(cfg.Listen))

--- a/component/storer.go
+++ b/component/storer.go
@@ -59,7 +59,7 @@ func makeStorer(
 			err := db.RunInTransaction(func(tx *pg.Tx) error {
 				// plain records
 
-				pulses := postgres.NewPulseStorage(cfg, obs, tx)
+				pulses := postgres.NewPulseStorage(log, tx)
 				err := pulses.Insert(b.pulse)
 				if err != nil {
 					return errors.Wrap(err, "failed to insert pulse")

--- a/internal/app/api/handlers_test.go
+++ b/internal/app/api/handlers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/insolar/insolar/insolar/gen"
 	"github.com/stretchr/testify/require"
 
+	"github.com/insolar/observer/internal/app/observer"
 	"github.com/insolar/observer/internal/app/observer/postgres"
 	"github.com/insolar/observer/internal/models"
 )
@@ -1142,7 +1143,6 @@ func TestMember_Hold(t *testing.T) {
 	memberWalletReference := gen.Reference()
 	memberAccountReference := gen.Reference()
 	balance := "5000"
-	clock.nowTime = currentTime
 
 	deposite := gen.Reference()
 	insertMember(t, member, &memberWalletReference, &memberAccountReference, balance)
@@ -1228,7 +1228,10 @@ func TestMember_Vesting(t *testing.T) {
 	err := db.Insert(&deposit)
 	require.NoError(t, err)
 
-	clock.nowTime = currentTime + deposit.VestingStep + 1
+	err = pStorage.Insert(&observer.Pulse{
+		Number: 60199947,
+	})
+	require.NoError(t, err)
 
 	resp, err := http.Get("http://" + apihost + "/api/member/" + member.String())
 	require.NoError(t, err)
@@ -1294,7 +1297,10 @@ func TestMember_VestingAll(t *testing.T) {
 	err := db.Insert(&deposit)
 	require.NoError(t, err)
 
-	clock.nowTime = currentTime + deposit.Vesting + 1
+	err = pStorage.Insert(&observer.Pulse{
+		Number: 60200937,
+	})
+	require.NoError(t, err)
 
 	resp, err := http.Get("http://" + apihost + "/api/member/" + member.String())
 	require.NoError(t, err)
@@ -1357,7 +1363,10 @@ func TestMember_VestingAndSpent(t *testing.T) {
 	err := db.Insert(&deposit)
 	require.NoError(t, err)
 
-	clock.nowTime = currentTime + deposit.VestingStep*11 + 1
+	err = pStorage.Insert(&observer.Pulse{
+		Number: 60200047,
+	})
+	require.NoError(t, err)
 
 	resp, err := http.Get("http://" + apihost + "/api/member/" + member.String())
 	require.NoError(t, err)

--- a/internal/app/observer/postgres/network_stats.go
+++ b/internal/app/observer/postgres/network_stats.go
@@ -23,6 +23,8 @@ import (
 	"github.com/go-pg/pg/orm"
 	"github.com/insolar/insolar/insolar"
 	"github.com/pkg/errors"
+
+	"github.com/insolar/observer/internal/models"
 )
 
 type NetworkStatsModel struct {
@@ -82,7 +84,7 @@ func (s *NetworkStatsRepository) CountStats() (NetworkStatsModel, error) {
 
 	// LastPulseNumber and Nodes
 	{
-		pulseSchema := PulseSchema{}
+		pulseSchema := models.Pulse{}
 		err := s.db.Model(&pulseSchema).
 			Order("pulse DESC").
 			Limit(1).
@@ -99,7 +101,7 @@ func (s *NetworkStatsRepository) CountStats() (NetworkStatsModel, error) {
 	// MonthTransactions
 	{
 		monthAgoPulse := uint32(insolar.GenesisPulse.PulseNumber)
-		pulseSchema := PulseSchema{}
+		pulseSchema := models.Pulse{}
 		err := s.db.Model(&pulseSchema).
 			Where("pulse_date < extract(epoch from (NOW() - INTERVAL '30 DAYS'))").
 			Order("pulse DESC").

--- a/internal/app/observer/postgres/network_stats_test.go
+++ b/internal/app/observer/postgres/network_stats_test.go
@@ -23,24 +23,18 @@ import (
 
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/insolar/gen"
+	"github.com/insolar/insolar/instrumentation/inslogger"
 	"github.com/stretchr/testify/require"
 
 	"github.com/insolar/observer/component"
-	"github.com/insolar/observer/configuration"
 	"github.com/insolar/observer/internal/app/observer"
 	"github.com/insolar/observer/internal/app/observer/postgres"
 	"github.com/insolar/observer/internal/models"
-	"github.com/insolar/observer/observability"
 )
 
 func TestCountStats(t *testing.T) {
-	cfg := &configuration.Configuration{
-		DB: configuration.DB{
-			Attempts: 1,
-		},
-	}
-
-	pulseRepo := postgres.NewPulseStorage(cfg, observability.Make(context.Background()), db)
+	log := inslogger.FromContext(context.Background())
+	pulseRepo := postgres.NewPulseStorage(log, db)
 
 	now := time.Now()
 

--- a/internal/app/observer/pulse.go
+++ b/internal/app/observer/pulse.go
@@ -31,7 +31,7 @@ type Pulse struct {
 
 type PulseStorage interface {
 	Insert(*Pulse) error
-	Last() *Pulse
+	Last() (*Pulse, error)
 }
 
 //go:generate minimock -i github.com/insolar/observer/internal/app/observer.PulseFetcher -o ./ -s _mock.go -g

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -133,6 +133,15 @@ type Notification struct {
 	Stop    time.Time `sql:"stop,notnull"`
 }
 
+type Pulse struct {
+	tableName struct{} `sql:"pulses"` //nolint: unused,structcheck
+
+	Pulse     uint32 `sql:"pulse,notnull"`
+	PulseDate int64  `sql:"pulse_date"`
+	Entropy   []byte `sql:"entropy"`
+	Nodes     uint32 `sql:"nodes"`
+}
+
 type fieldCache struct {
 	sync.Mutex
 	cache map[reflect.Type][]string

--- a/scripts/migrations/1_scheme.up.sql
+++ b/scripts/migrations/1_scheme.up.sql
@@ -85,7 +85,6 @@ create table if not exists pulses
             primary key,
     pulse_date bigint,
     entropy varchar(256),
-    requests_count integer,
     nodes bigint
 );
 


### PR DESCRIPTION
base deposits math on latest synced pulse, not the current wallclock
time