### PR TITLE
INS-4122: failed tx without saga

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/labstack/echo/v4 v4.1.11
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/ory/dockertest/v3 v3.5.1
@@ -33,6 +35,7 @@ require (
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
 	golang.org/x/sys v0.0.0-20191020212454-3e7259c5e7c2 // indirect
 	gonum.org/v1/gonum v0.6.0 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect
 	google.golang.org/grpc v1.21.0
 	gopkg.in/yaml.v2 v2.2.7

--- a/internal/app/observer/transaction.go
+++ b/internal/app/observer/transaction.go
@@ -53,16 +53,22 @@ func (t *TxRegister) Validate() error {
 	return nil
 }
 
+type TxFailed struct {
+	FinishPulseNumber  int64
+	FinishRecordNumber int64
+}
+
 type TxResult struct {
 	TransactionID insolar.Reference
 	Fee           string
+	Failed        *TxFailed
 }
 
 func (t *TxResult) Validate() error {
 	if t.TransactionID.IsEmpty() {
 		return errors.New("TransactionID should not be empty")
 	}
-	if len(t.Fee) == 0 {
+	if t.Failed == nil && len(t.Fee) == 0 {
 		return errors.New("Fee should not be empty")
 	}
 	return nil


### PR DESCRIPTION
new case - failed transaction (request with signature of differnt user), we need to be able to register failed results without saga

- added TxResultCollector logic and test
- added Storer support for failed tx and test