### PR TITLE
Add ca-certificates package to runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ COPY ./ /observer
 RUN make build
 
 FROM debian:buster-slim as app
+RUN apt update && apt install -y ca-certificates && apt-get clean all
 COPY $PWD/scripts/migrations /migrations
 COPY --from=build /observer/bin/observer /observer/bin/api /observer/bin/stats-collector /observer/bin/migrate /observer/bin/binance-collector /observer/bin/coin-market-cap-collector /usr/local/bin/


### PR DESCRIPTION
Now we can properly communicate with exchanges API via https