### PR TITLE
MN-427: delete deprecated metrics

### DIFF
--- a/observability/observability.go
+++ b/observability/observability.go
@@ -91,13 +91,10 @@ func MakeBeautyMetrics(obs *Observability, action string) *BeautyMetrics {
 }
 
 type BeautyMetrics struct {
-	Pulses      prometheus.Counter
-	Records     prometheus.Counter
-	Requests    prometheus.Counter
-	Results     prometheus.Counter
-	Activates   prometheus.Counter
-	Amends      prometheus.Counter
-	Deactivates prometheus.Counter
+	Pulses   prometheus.Counter
+	Records  prometheus.Counter
+	Requests prometheus.Counter
+	Results  prometheus.Counter
 
 	Transfers prometheus.Counter
 	Members   prometheus.Counter


### PR DESCRIPTION
Delete deprecated metrics after review collectors
https://insolar.atlassian.net/browse/MN-427
https://insolar.atlassian.net/browse/INS-3739

pr - delete metrics in grafana https://github.com/insolar/adm/pull/486