### PR TITLE
MN-691: fix transaction api

### DIFF
--- a/component/storer.go
+++ b/component/storer.go
@@ -289,6 +289,7 @@ func StoreTxRegister(tx Execer, transactions []observer.TxRegister) error {
 		"member_from_ref",
 		"member_to_ref",
 		"deposit_to_ref",
+		"deposit_from_ref",
 		"amount",
 	}
 	var values []interface{}
@@ -302,6 +303,7 @@ func StoreTxRegister(tx Execer, transactions []observer.TxRegister) error {
 			t.MemberFromReference,
 			t.MemberToReference,
 			t.DepositToReference,
+			t.DepositFromReference,
 			t.Amount,
 		)
 	}

--- a/internal/app/api/mappers.go
+++ b/internal/app/api/mappers.go
@@ -52,6 +52,24 @@ func TxToAPITx(tx models.Transaction, indexType models.TxIndexType) interface{} 
 		}
 
 		return res
+	case models.TTypeAllocation:
+		res := SchemaMigration{
+			SchemasTransactionAbstract: internalTx,
+			Type:                       string(tx.Type),
+		}
+		if len(tx.MemberFromReference) > 0 {
+			ref := insolar.NewReferenceFromBytes(tx.MemberFromReference)
+			res.FromMemberReference = ref.String()
+		}
+		if len(tx.DepositToReference) > 0 {
+			ref := insolar.NewReferenceFromBytes(tx.DepositToReference)
+			res.ToDepositReference = ref.String()
+		}
+		if len(tx.MemberToReference) > 0 {
+			ref := insolar.NewReferenceFromBytes(tx.MemberToReference)
+			res.ToMemberReference = ref.String()
+		}
+		return res
 	case models.TTypeTransfer:
 		res := SchemaTransfer{
 			SchemasTransactionAbstract: internalTx,

--- a/internal/app/api/mappers.go
+++ b/internal/app/api/mappers.go
@@ -33,7 +33,7 @@ func TxToAPITx(tx models.Transaction, indexType models.TxIndexType) interface{} 
 	}
 
 	switch tx.Type {
-	case models.TTypeMigration:
+	case models.TTypeMigration, models.TTypeAllocation:
 		res := SchemaMigration{
 			SchemasTransactionAbstract: internalTx,
 			Type:                       string(tx.Type),
@@ -51,24 +51,6 @@ func TxToAPITx(tx models.Transaction, indexType models.TxIndexType) interface{} 
 			res.ToMemberReference = ref.String()
 		}
 
-		return res
-	case models.TTypeAllocation:
-		res := SchemaMigration{
-			SchemasTransactionAbstract: internalTx,
-			Type:                       string(tx.Type),
-		}
-		if len(tx.MemberFromReference) > 0 {
-			ref := insolar.NewReferenceFromBytes(tx.MemberFromReference)
-			res.FromMemberReference = ref.String()
-		}
-		if len(tx.DepositToReference) > 0 {
-			ref := insolar.NewReferenceFromBytes(tx.DepositToReference)
-			res.ToDepositReference = ref.String()
-		}
-		if len(tx.MemberToReference) > 0 {
-			ref := insolar.NewReferenceFromBytes(tx.MemberToReference)
-			res.ToMemberReference = ref.String()
-		}
 		return res
 	case models.TTypeTransfer:
 		res := SchemaTransfer{

--- a/internal/app/api/mappers_test.go
+++ b/internal/app/api/mappers_test.go
@@ -6,6 +6,9 @@
 package api
 
 import (
+	"github.com/insolar/insolar/insolar"
+	"github.com/insolar/insolar/insolar/gen"
+	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
 
@@ -305,4 +308,39 @@ func TestNextRelease(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAllocationTransactions(t *testing.T) {
+	memberFrom := gen.Reference()
+	memberTo := gen.Reference()
+	depositTo := gen.Reference()
+	tx := models.Transaction{
+		Amount:              "100",
+		Fee:                 *NullableString("0"),
+		StatusRegistered:    true,
+		TransactionID:       gen.Reference().Bytes(),
+		Type:                models.TTypeAllocation,
+		MemberFromReference: memberFrom.Bytes(),
+		MemberToReference:   memberTo.Bytes(),
+		DepositToReference:  depositTo.Bytes(),
+	}
+	indexType := models.TxIndexTypeFinishPulseRecord
+	txMigration := SchemaMigration{
+		SchemasTransactionAbstract: SchemasTransactionAbstract{
+			Amount:      tx.Amount,
+			Fee:         NullableString(tx.Fee),
+			Index:       tx.Index(indexType),
+			PulseNumber: tx.PulseNumber(),
+			Status:      string(tx.Status()),
+			Timestamp:   tx.Timestamp(),
+			TxID:        insolar.NewReferenceFromBytes(tx.TransactionID).String(),
+			Type:        string(tx.Type),
+		},
+		Type:                string(tx.Type),
+		FromMemberReference: memberFrom.String(),
+		ToMemberReference:   memberTo.String(),
+		ToDepositReference:  depositTo.String(),
+	}
+	res := TxToAPITx(tx, indexType)
+	require.Equal(t, txMigration, res.(SchemaMigration))
 }

--- a/internal/app/observer/collecting/transactions.go
+++ b/internal/app/observer/collecting/transactions.go
@@ -273,15 +273,20 @@ func (c *TxRegisterCollector) fromDepositToDeposit(log insolar.Logger, rec expor
 
 	log = log.WithField("tx_id", txID.GetLocal().DebugString())
 	log.Debug("created TxRegister")
+	var fromDeposit []byte
+	if !request.Caller.IsEmpty() {
+		fromDeposit = request.Caller.Bytes()
+	}
 	return &observer.TxRegister{
-		Type:                models.TransactionType(txType),
-		TransactionID:       txID,
-		PulseNumber:         int64(rec.Record.ID.Pulse()),
-		RecordNumber:        int64(rec.RecordNumber),
-		MemberFromReference: fromMember.Bytes(),
-		MemberToReference:   toMember.Bytes(),
-		DepositToReference:  toDeposit.Bytes(),
-		Amount:              amount,
+		Type:                 models.TransactionType(txType),
+		TransactionID:        txID,
+		PulseNumber:          int64(rec.Record.ID.Pulse()),
+		RecordNumber:         int64(rec.RecordNumber),
+		MemberFromReference:  fromMember.Bytes(),
+		MemberToReference:    toMember.Bytes(),
+		DepositToReference:   toDeposit.Bytes(),
+		DepositFromReference: fromDeposit,
+		Amount:               amount,
 	}
 }
 

--- a/internal/app/observer/collecting/transactions_test.go
+++ b/internal/app/observer/collecting/transactions_test.go
@@ -140,15 +140,17 @@ func TestTxRegisterCollector_Collect(t *testing.T) {
 		memberFrom := gen.Reference()
 		memberTo := gen.Reference()
 		depositTo := gen.Reference()
+		caller := gen.Reference()
 		expectedTx := observer.TxRegister{
-			TransactionID:       txID,
-			Type:                models.TTypeMigration,
-			PulseNumber:         int64(txID.GetLocal().Pulse()),
-			RecordNumber:        int64(rand.Int31()),
-			MemberFromReference: memberFrom.Bytes(),
-			MemberToReference:   memberTo.Bytes(),
-			DepositToReference:  depositTo.Bytes(),
-			Amount:              "123",
+			TransactionID:        txID,
+			Type:                 models.TTypeMigration,
+			PulseNumber:          int64(txID.GetLocal().Pulse()),
+			RecordNumber:         int64(rand.Int31()),
+			MemberFromReference:  memberFrom.Bytes(),
+			MemberToReference:    memberTo.Bytes(),
+			DepositToReference:   depositTo.Bytes(),
+			DepositFromReference: caller.Bytes(),
+			Amount:               "123",
 		}
 
 		arguments, err := insolar.Serialize([]interface{}{
@@ -166,7 +168,7 @@ func TestTxRegisterCollector_Collect(t *testing.T) {
 					Method:     methodTransferToDeposit,
 					ReturnMode: record.ReturnResult,
 					Arguments:  arguments,
-					Caller:     gen.Reference(),
+					Caller:     caller,
 					Prototype:  proxyDeposit.PrototypeReference,
 				}),
 				ID: *txID.GetLocal(),
@@ -184,15 +186,17 @@ func TestTxRegisterCollector_Collect(t *testing.T) {
 		memberFrom := gen.Reference()
 		memberTo := gen.Reference()
 		depositTo := gen.Reference()
+		caller := gen.Reference()
 		expectedTx := observer.TxRegister{
-			TransactionID:       txID,
-			Type:                models.TTypeMigration,
-			PulseNumber:         int64(txID.GetLocal().Pulse()),
-			RecordNumber:        int64(rand.Int31()),
-			MemberFromReference: memberFrom.Bytes(),
-			MemberToReference:   memberTo.Bytes(),
-			DepositToReference:  depositTo.Bytes(),
-			Amount:              "123",
+			TransactionID:        txID,
+			Type:                 models.TTypeMigration,
+			PulseNumber:          int64(txID.GetLocal().Pulse()),
+			RecordNumber:         int64(rand.Int31()),
+			MemberFromReference:  memberFrom.Bytes(),
+			MemberToReference:    memberTo.Bytes(),
+			DepositToReference:   depositTo.Bytes(),
+			DepositFromReference: caller.Bytes(),
+			Amount:               "123",
 		}
 
 		arguments, err := insolar.Serialize([]interface{}{
@@ -209,7 +213,7 @@ func TestTxRegisterCollector_Collect(t *testing.T) {
 					Method:     methodTransferToDeposit,
 					ReturnMode: record.ReturnResult,
 					Arguments:  arguments,
-					Caller:     gen.Reference(),
+					Caller:     caller,
 					Prototype:  proxyDeposit.PrototypeReference,
 				}),
 				ID: *txID.GetLocal(),
@@ -227,15 +231,17 @@ func TestTxRegisterCollector_Collect(t *testing.T) {
 		memberFrom := gen.Reference()
 		memberTo := gen.Reference()
 		depositTo := gen.Reference()
+		caller := gen.Reference()
 		expectedTx := observer.TxRegister{
-			TransactionID:       txID,
-			Type:                models.TTypeAllocation,
-			PulseNumber:         int64(txID.GetLocal().Pulse()),
-			RecordNumber:        int64(rand.Int31()),
-			MemberFromReference: memberFrom.Bytes(),
-			MemberToReference:   memberTo.Bytes(),
-			DepositToReference:  depositTo.Bytes(),
-			Amount:              "123",
+			TransactionID:        txID,
+			Type:                 models.TTypeAllocation,
+			PulseNumber:          int64(txID.GetLocal().Pulse()),
+			RecordNumber:         int64(rand.Int31()),
+			MemberFromReference:  memberFrom.Bytes(),
+			MemberToReference:    memberTo.Bytes(),
+			DepositToReference:   depositTo.Bytes(),
+			DepositFromReference: caller.Bytes(),
+			Amount:               "123",
 		}
 
 		arguments, err := insolar.Serialize([]interface{}{
@@ -253,7 +259,7 @@ func TestTxRegisterCollector_Collect(t *testing.T) {
 					Method:     methodTransferToDeposit,
 					ReturnMode: record.ReturnResult,
 					Arguments:  arguments,
-					Caller:     gen.Reference(),
+					Caller:     caller,
 					Prototype:  proxyDeposit.PrototypeReference,
 				}),
 				ID: *txID.GetLocal(),
@@ -270,14 +276,15 @@ func TestTxRegisterCollector_Collect(t *testing.T) {
 		txID := *insolar.NewRecordReference(gen.ID())
 		memberTo := gen.Reference()
 		expectedTx := observer.TxRegister{
-			TransactionID:       txID,
-			Type:                models.TTypeRelease,
-			PulseNumber:         int64(txID.GetLocal().Pulse()),
-			RecordNumber:        int64(rand.Int31()),
-			MemberFromReference: nil,
-			MemberToReference:   memberTo.Bytes(),
-			DepositToReference:  nil,
-			Amount:              "123",
+			TransactionID:        txID,
+			Type:                 models.TTypeRelease,
+			PulseNumber:          int64(txID.GetLocal().Pulse()),
+			RecordNumber:         int64(rand.Int31()),
+			MemberFromReference:  nil,
+			MemberToReference:    memberTo.Bytes(),
+			DepositToReference:   nil,
+			DepositFromReference: nil,
+			Amount:               "123",
 		}
 
 		request := member.Request{

--- a/internal/app/observer/transaction.go
+++ b/internal/app/observer/transaction.go
@@ -13,14 +13,15 @@ import (
 )
 
 type TxRegister struct {
-	TransactionID       insolar.Reference
-	Type                models.TransactionType
-	PulseNumber         int64
-	RecordNumber        int64
-	MemberFromReference []byte
-	MemberToReference   []byte
-	DepositToReference  []byte
-	Amount              string
+	TransactionID        insolar.Reference
+	Type                 models.TransactionType
+	PulseNumber          int64
+	RecordNumber         int64
+	MemberFromReference  []byte
+	MemberToReference    []byte
+	DepositToReference   []byte
+	DepositFromReference []byte
+	Amount               string
 }
 
 func (t *TxRegister) Validate() error {


### PR DESCRIPTION
what I did:
- add to the TxToAPITx func transaction allocation type
- store fromDepositReference to DB