### PR TITLE
MN-826: correct method name to change burn transaction status

### DIFF
--- a/internal/app/observer/collecting/transactions.go
+++ b/internal/app/observer/collecting/transactions.go
@@ -38,7 +38,7 @@ const (
 	methodTransferToDeposit = "TransferToDeposit"
 	methodTransfer          = "Transfer"
 	methodAccept            = "Accept"
-	methodBurnAccept        = "BurnAccept"
+	methodBurnAccept        = "AcceptBurn"
 )
 
 const (


### PR DESCRIPTION
Set correct method name to change burn transaction status after it was accepted